### PR TITLE
Potential fix for code scanning alert no. 19: Missing rate limiting

### DIFF
--- a/routes/cart.js
+++ b/routes/cart.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 const router = Router();
 
+import rateLimit from 'express-rate-limit';
 import {
   getAllCarts,
   getSingleCart,
@@ -9,6 +10,13 @@ import {
   editCart,
   deleteCart
 } from '../controller/cart.js';
+
+// Strict rate limiter for destructive actions
+const deleteCartLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // limit each IP to 5 delete requests per windowMs
+  message: 'Too many delete requests from this IP, please try again later'
+});
 
 // More specific route first
 router.get('/user/:userid', getCartsByUserid);
@@ -27,6 +35,6 @@ router.put('/:id', editCart);
 router.patch('/:id', editCart);
 
 // Delete cart
-router.delete('/:id', deleteCart);
+router.delete('/:id', deleteCartLimiter, deleteCart);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/xrankit/ecommerce_store_api/security/code-scanning/19](https://github.com/xrankit/ecommerce_store_api/security/code-scanning/19)

To fix the problem, we should add rate-limiting middleware to the DELETE `/cart/:id` endpoint (line 30) to restrict the number of requests that clients can make in a given time window. The best way to do this is with the popular express-rate-limit package.  
- We need to import express-rate-limit (using `require` since ES modules are not available in npm for this package, or use dynamic import).
- Define a rate-limiter instance with sensible defaults (e.g., 5 DELETE requests per 15 minutes for destructive actions).
- Apply the limiter to the DELETE route only to avoid unnecessary restrictions on reads or non-destructive actions.
Changes needed:
- At the top of `routes/cart.js`, import express-rate-limit.
- Create a rate limiter for DELETE requests.
- Add the rate limiter as middleware on the DELETE route (line 30).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
