### PR TITLE
Potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/controller/user.js
+++ b/controller/user.js
@@ -78,9 +78,22 @@ export async function editUser(req, res) {
         }
 
         const id = parseInt(req.params.id);
+        const allowedFields = ['email', 'username', 'name', 'address', 'phone'];
+        const safeUpdate = {};
+        for (const key of allowedFields) {
+            if (Object.prototype.hasOwnProperty.call(req.body, key)) {
+                safeUpdate[key] = req.body[key];
+            }
+        }
+        if (Object.keys(safeUpdate).length === 0) {
+            return res.status(400).json({
+                status: 'error',
+                message: 'No valid fields to update',
+            });
+        }
         const updatedUser = await User.findOneAndUpdate(
             { id },
-            { $set: req.body },
+            { $set: safeUpdate },
             { new: true }
         ).select('-_id');
 


### PR DESCRIPTION
Potential fix for [https://github.com/xrankit/ecommerce_store_api/security/code-scanning/4](https://github.com/xrankit/ecommerce_store_api/security/code-scanning/4)

To fix the problem, you should sanitize and filter the user input before passing it as `$set` in the update query. Specifically, only allow updates to known safe fields. Define an array of allowed fields (such as 'email', 'username', 'name', 'address', and 'phone'), and build a new update object containing only those fields present in the `req.body`. Then use this sanitized object as the value of `$set` in the update query, thereby preventing the possibility of passing dangerous MongoDB operators or unexpected fields.

You only need to edit lines inside the controller/user.js file, specifically inside the `editUser` function. No changes to other files or to the schema/model file. No external sanitization libraries are needed since this is simple key whitelisting.

You'll need to define an array of permitted fields inside the `editUser` function, build the sanitized update object, and then use `{ $set: safeUpdate }` instead of `{ $set: req.body }` in line 83.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
