### PR TITLE
Potential fix for code scanning alert no. 33: Database query built from user-controlled sources

### DIFF
--- a/controller/product.js
+++ b/controller/product.js
@@ -106,7 +106,18 @@ export async function editProduct(req, res) {
         const update = {};
         for (const key of allowedUpdates) {
             if (Object.prototype.hasOwnProperty.call(req.body, key)) {
-                update[key] = req.body[key];
+                const value = req.body[key];
+                // Only allow primitive types (string, number, boolean, null) as values for update
+                if (
+                    value !== null &&
+                    (typeof value === 'object' || Array.isArray(value))
+                ) {
+                    return res.status(400).json({
+                        status: 'error',
+                        message: `Invalid value for field '${key}': must not be object or array`,
+                    });
+                }
+                update[key] = value;
             }
         }
         if (Object.keys(update).length === 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/xrankit/ecommerce_store_api/security/code-scanning/33](https://github.com/xrankit/ecommerce_store_api/security/code-scanning/33)

To fix the vulnerability, we should ensure that the values assigned to the `update` object are safe for use in a MongoDB update query. Specifically, we should ensure that none of the values are objects containing MongoDB update/query operators. This can be accomplished by only allowing primitive types (string, number, boolean, null) as values for updates.  
The best, least-intrusive way to implement this is to check the type of each value before assignment—if the value is an object or array (excluding `null`), the update should be rejected. This can be implemented inside the loop where we assign properties to the `update` object. If any value is unsafe, we should return an error without performing the update.

Where to change:  
- In the for-of loop that copies allowed keys from `req.body` to `update`, add a check: only allow string, number, boolean, or `null` as value, *not* objects or arrays.
- If an invalid value is found, return a 400 error response immediately, rejecting the request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
