### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/controller/cart.js
+++ b/controller/cart.js
@@ -84,9 +84,21 @@ export async function editCart(req, res) {
     const id = parseInt(req.params.id);
     if (!req.body) return res.status(400).json({ message: "Data is required" });
 
+    // Only allow specific fields to be updated
+    const allowedFields = ['userId', 'date', 'products'];
+    const sanitizedBody = {};
+    for (const key of allowedFields) {
+      if (Object.prototype.hasOwnProperty.call(req.body, key)) {
+        sanitizedBody[key] = req.body[key];
+      }
+    }
+    if (Object.keys(sanitizedBody).length === 0) {
+      return res.status(400).json({ message: "No valid fields to update" });
+    }
+
     const updatedCart = await Cart.findOneAndUpdate(
       { id },
-      { $set: req.body },
+      { $set: sanitizedBody },
       { new: true }
     ).select("-_id -products._id");
 


### PR DESCRIPTION
Potential fix for [https://github.com/xrankit/ecommerce_store_api/security/code-scanning/2](https://github.com/xrankit/ecommerce_store_api/security/code-scanning/2)

To fix this issue, we should restrict and sanitize what fields a user is allowed to update and prevent operator injection by ensuring that only valid, expected fields are in the `$set` object. One robust way to do this is to build the `$set` object explicitly by picking only allowed fields from `req.body` (such as those defined in the Cart schema, e.g., `userId`, `date`, `products`), and ignore everything else. This avoids passing unexpected keys or query operators provided by the client.  
- In the file `controller/cart.js`, specifically in the `editCart` function (lines 82-99), replace the usage `{ $set: req.body }` with `{ $set: sanitizedBody }` where `sanitizedBody` is an object containing only the permitted fields extracted from `req.body`.  
- Add code which creates `sanitizedBody` from the allowed Cart fields, e.g.:
  ```js
  const allowedFields = ['userId', 'date', 'products'];
  const sanitizedBody = {};
  for (const key of allowedFields) {
      if (req.body.hasOwnProperty(key)) {
          sanitizedBody[key] = req.body[key];
      }
  }
  ```
- Only proceed if there is at least one allowed field to update (otherwise, return an error).

No new methods or imports are needed; you can add this sanitization inline inside the function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
