### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/routes/product.js
+++ b/routes/product.js
@@ -21,7 +21,7 @@ import {
 router.get("/categories", limiter, getProductCategories);
 
 // Get products in a specific category
-router.get("/category/:category", getProductsInCategory);
+router.get("/category/:category", limiter, getProductsInCategory);
 
 // Get single product by numeric id
 router.get("/:id", getProduct);


### PR DESCRIPTION
Potential fix for [https://github.com/xrankit/ecommerce_store_api/security/code-scanning/8](https://github.com/xrankit/ecommerce_store_api/security/code-scanning/8)

The best way to fix this issue is by adding the existing `limiter` middleware to the `/category/:category` route so that rate limiting is enforced. This is done by inserting `limiter` as the second argument to the relevant router handler, analogous to how `/categories`, `put`, `patch`, and `delete` routes have been protected. No additional dependency or configuration is needed as the `limiter` is already declared and imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
